### PR TITLE
fix numbers align

### DIFF
--- a/lib/app/components/code_editor/code_field/code_field.dart
+++ b/lib/app/components/code_editor/code_field/code_field.dart
@@ -229,6 +229,7 @@ class _CodeFieldState extends State<CodeField> {
     final defaultTextStyle = TextStyle(
       color: styles?[rootKey]?.color ?? DefaultStyles.textColor,
       fontSize: themeData.textTheme.titleMedium?.fontSize,
+      height: 1,
     );
 
     textStyle = defaultTextStyle.merge(widget.textStyle);


### PR DESCRIPTION
Fixed issue with numbers alignment(#4)

Before:
![image](https://github.com/user-attachments/assets/74a31058-71f1-4bf0-9a00-3179868d1f88)

After:
![image](https://github.com/user-attachments/assets/7dd014a6-f571-42de-8807-278e618abd2b)